### PR TITLE
Change interface of addOrUpdateProfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dependencies:
 ### Integration tests
 
 ```bash
-$ grunt test-integration
+$ grunt test
 ```
 
 To run the integration tests you need to be running platform components locally, see the [Runservers Script](https://github.com/tidepool-org/tools).

--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ module.exports = function (config, deps) {
    * @returns {cb}  cb(err, response)
    */
   function doGetWithToken(path, codes, cb) {
-    //if the cb is not defined and the codes param is a function then set that 
+    //if the cb is not defined and the codes param is a function then set that
     //to be the cb
     if (cb == null && typeof(codes) === 'function') {
       cb = codes;
@@ -583,21 +583,17 @@ module.exports = function (config, deps) {
     /**
      * Add a new or update an existing profile for a user
      *
-     * @param {Object} user object with profile info and `id` attribute
+     * @param {String} userId id of the user you are updating the profile of
+     * @param {Object} profile object
      * @param cb
      * @returns {cb}  cb(err, response)
      */
-    addOrUpdateProfile: function (user, cb) {
-      if (user.id == null) {
-        return cb({ message: 'Must specify an id' });
-      }
-      assertArgumentsSize(arguments, 2);
-
-      var userProfile = _.omit(user, 'id', 'username', 'password', 'emails');
+    addOrUpdateProfile: function (userId, profile, cb) {
+      assertArgumentsSize(arguments, 3);
 
       doPutWithToken(
-        '/metadata/' + user.id + '/profile',
-        userProfile,
+        '/metadata/' + userId + '/profile',
+        profile,
         cb
       );
     },

--- a/test/integration/tidepoolPlatform_integration.js
+++ b/test/integration/tidepoolPlatform_integration.js
@@ -44,8 +44,7 @@ describe('platform client', function () {
     username: 'a_PWD@user.com',
     password: 'a_PWD',
     emails: ['a_PWD@user.com'],
-    firstName: 'Jamie',
-    lastName: 'T1'
+    profile: {fullName: 'Jamie'}
   };
 
   /*
@@ -63,8 +62,7 @@ describe('platform client', function () {
     username: 'team@member.com',
     password: 'teammember',
     emails: ['team@member.com'],
-    firstName: 'Dr Doogie',
-    lastName: 'Howser'
+    profile: {fullName: 'Dr Doogie'}
   };
 
   function createClient(user, loginOpts, mockedLocalStore ,cb) {
@@ -222,8 +220,8 @@ describe('platform client', function () {
     it('so we can add or update the logged in users profile', function (done) {
       //add or update for both our users
       async.parallel([
-        pwdClient.addOrUpdateProfile.bind(null,a_PWD),
-        memberClient.addOrUpdateProfile.bind(null,a_Member)
+        pwdClient.addOrUpdateProfile.bind(null, a_PWD.id, a_PWD.profile),
+        memberClient.addOrUpdateProfile.bind(null, a_Member.id, a_Member.profile)
       ],
         function(err, profiles) {
           if (err != null) {
@@ -239,8 +237,7 @@ describe('platform client', function () {
         expect(error).to.not.exist;
 
         expect(profile).to.exist;
-        expect(profile.firstName).to.equal(a_Member.firstName);
-        expect(profile.lastName).to.equal(a_Member.lastName);
+        expect(profile.fullName).to.equal(a_Member.profile.fullName);
         expect(profile).to.not.have.property('password');
         expect(profile).to.not.have.property('username');
 
@@ -253,8 +250,7 @@ describe('platform client', function () {
         expect(error).to.not.exist;
 
         expect(profile).to.be.exist;
-        expect(profile.firstName).to.equal(a_Member.firstName);
-        expect(profile.lastName).to.equal(a_Member.lastName);
+        expect(profile.fullName).to.equal(a_Member.profile.fullName);
         expect(profile).to.not.have.property('password');
         expect(profile).to.not.have.property('username');
         done();


### PR DESCRIPTION
Before: `addOrUpdateProfile(user, cb)`
After: `addOrUpdateProfile(userId, profile, cb)`

I find it more consistent with other methods, and also fits better when used in Blip? See below:

Before I had something like this:

``` javascript
var userId = '123';
var profile = {fullName: 'Mary Smith'};

// need to add `id` to update profile
profile.id = userId;
addOrUpdateProfile(profile, function(err, profile) { /*...*/ });
```

Now I can do this, which I find clearer?

``` javascript
var userId = '123';
var profile = {fullName: 'Mary Smith'};

addOrUpdateProfile(userId, profile, function(err, profile) { /*...*/ });
```

This is a breaking change so would need to update version to `0.6.0`. I think only Blip uses this method at the moment?
