### PR TITLE
Fixes for Blip's Access & Invitations feature branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -866,12 +866,12 @@ module.exports = function (config, deps) {
       );
     },
     /**
-     * Get the invites recieved
+     * Get the invites received
      *
      * @param cb
      * @returns {cb}  cb(err, response)
      */
-    invitesRecieved: function (cb) {
+    invitesReceived: function (cb) {
       assertArgumentsSize(arguments, 1);
 
       var self = this;

--- a/test/integration/tidepoolPlatform_integration.js
+++ b/test/integration/tidepoolPlatform_integration.js
@@ -569,7 +569,7 @@ describe('platform client', function () {
     it('a_Member can see the invites they have received', function(done){
       pwdClient.inviteUser(a_Member.emails[0],{view: {}}, a_PWD.id,function(err, invite) {
         expect(err).to.be.empty;
-        memberClient.invitesRecieved(a_Member.id,function(err, received) {
+        memberClient.invitesReceived(a_Member.id,function(err, received) {
           expect(err).to.be.empty;
           expect(received).to.not.be.empty;
           done();


### PR DESCRIPTION
Hey @jh-bate, let me know what you think:

Instead of going from raw received invites objects that have:

``` javascript
{
  // ...
  "creatorId": "11"
}
```

To:

``` javascript
{
  // ...
  "creatorId": "11",
  "creator": {"fullName": "Mary Smith"}
}
```

I'd like to completely replace the `creatorId` with a **full user object**:

``` javascript
{
  // ...
  "creator": {
    "userid": "11",
    "profile": {"fullName": "Mary Smith"}
  }
}
```

I'm trying to follow this consistency of "user objects" (at the top-level, a "userid" field, and a "profile" blob; if the user is you, you also have your "username" and "emails"), throughout the app and APIs...

/cc @ianjorgensen 
