### PR TITLE
add GUIDs for notes (new threads and replies)

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
 'use strict';
 
 var _ = require('lodash');
+var uuid = require('node-uuid');
 
 var id = require('./lib/id.js');
 
@@ -556,7 +557,7 @@ module.exports = function (config, deps) {
 
       common.doPostWithToken(
         '/message/reply/' + comment.parentmessage,
-        {message: comment},
+        { message: _.assign(comment, {guid: uuid.v4()}) },
         { 201: function(res){ return res.body.id; }},
         cb
       );
@@ -577,7 +578,7 @@ module.exports = function (config, deps) {
 
       common.doPostWithToken(
         '/message/send/' + message.groupid,
-        { message: message },
+        { message: _.assign(message, {guid: uuid.v4()}) },
         { 201: function(res){ return res.body.id; }},
         cb
       );

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "async": "0.9.0",
     "crypto": "0.0.3",
     "lodash": "3.3.1",
+    "node-uuid": "1.4.3",
     "superagent": "0.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Add RFC4122 version 4 UUIDs (aka GUIDs) on new message threads and replies.

This should cover note creation in both blip and clamshell, along with [message-api PR 33](https://github.com/tidepool-org/message-api/pull/33). blip and clamshell deployments using this platform-client should go through first - message-api won't store the GUIDs until it's deployed too, but we won't try to store any null GUIDs if we get the GUID *creation* through first, which would be good.

@jh-bate what's up with the tests in this repo? There are a bunch still pending? Do you feel a need for me to add/amend some because of these changes?