### PR TITLE
S3 Uploads (platform-client)

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,7 +450,7 @@ module.exports = function (config, deps) {
           }
 
           var syncTask = res.body;
-          var syncTaskId = syncTask._id;
+          var syncTaskId = syncTask.id;
 
           if (!syncTaskId) {
             log.info('Upload Failed');


### PR DESCRIPTION
@jh-bate @jebeck Changes to platform-client for S3 uploads.  Just renamed `_id` to `id` on syncTask for consistently.  Will need a tag and push to npm to actually work on more than local environment.