### PR TITLE
fix regression in shape/type of response when upload metadata POST fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,6 +355,13 @@ module.exports = function (config, deps) {
           if (err != null) {
             return cb(err);
           }
+          else if (res.error != null) {
+            // reshape client error response in the way the uploader currently expects
+            // for the minimum version check (may apply elsewhere too)
+            var clientError = {message: JSON.parse(res.text)};
+            clientError.message.reason = clientError.message.text;
+            return cb(_.omit(clientError, 'text'));
+          }
           return cb(null,res.body);
         });
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-platform-client",
-  "version": "0.19.0",
+  "version": "0.19.0-hotfix",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "scripts": {


### PR DESCRIPTION
This is definitely a hack. I think the real location of the regression is jellyfish's error responses. However, this works and we need to get something out fast for the DST warning.

Thoughts @darinkrauss?