### PR TITLE
improving error handling for createDatasetForUser

### DIFF
--- a/index.js
+++ b/index.js
@@ -373,8 +373,6 @@ module.exports = function (config, deps) {
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .end(
         function (err, res) {
-          console.log("err", err, "res", res);
-
           if (err != null) {
             return cb(err);
           } else if (res.error === true) {
@@ -384,8 +382,7 @@ module.exports = function (config, deps) {
               return cb(res.error);
             }
           } else if (res.status !== 201) {
-            var errText = 'Unexpected HTTP response: ' + res.status;
-            return cb(new Error(errText));
+            return cb(new Error('Unexpected HTTP response: ' + res.status));
           }
 
           return cb(null, res.body);

--- a/index.js
+++ b/index.js
@@ -373,10 +373,11 @@ module.exports = function (config, deps) {
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .end(
         function (err, res) {
+          console.log("err", err, "res", res);
 
           if (err != null) {
             return cb(err);
-          } else if (res.error != null) {
+          } else if (res.error === true) {
             if(_.isObject(res.body)) {
               return cb(res.body); // for our custom error arrays
             } else {

--- a/index.js
+++ b/index.js
@@ -376,8 +376,11 @@ module.exports = function (config, deps) {
 
           if (err != null) {
             return cb(err);
+          } else if (res.error != null) {
+            return cb(res.error);
           } else if (res.status !== 201) {
-            return cb(res.body);
+            var errText = 'Unexpected HTTP response: ' + res.status;
+            return cb(new Error(errText));
           }
 
           return cb(null, res.body);

--- a/index.js
+++ b/index.js
@@ -377,7 +377,11 @@ module.exports = function (config, deps) {
           if (err != null) {
             return cb(err);
           } else if (res.error != null) {
-            return cb(res.error);
+            if(_.isObject(res.body)) {
+              return cb(res.body); // for our custom error arrays
+            } else {
+              return cb(res.error);
+            }
           } else if (res.status !== 201) {
             var errText = 'Unexpected HTTP response: ' + res.status;
             return cb(new Error(errText));


### PR DESCRIPTION
The existing error handling returns `null` for POST errors, so I've changed it to return the correct HTTP error, or create a new error if the HTTP response is unexpected.

Ping @darinkrauss for review.