### PR TITLE
Adds X-Tidepool-Trace-Session header to all API requests 

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,21 @@ module.exports = function (config, deps) {
     findMetadata(userId, 'profile', cb);
   }
 
+  /**
+   * format error with response body and session token
+   *
+   * @param {Error} err with the response body
+   * @returns {Error}
+   */
+  function formatError (err) {
+    if (err.response && err.response.body) {
+      var error = err.response.body;
+      error.sessionToken = user.getUserToken();
+      return error;
+    }
+    return err;
+  }
+
   return {
     /**
      * Do any requied initialization
@@ -480,7 +495,9 @@ module.exports = function (config, deps) {
         .end(
         function (err, res) {
           if (err != null) {
-            err.sessionToken = user.getUserToken();
+            if (err.status !== 201) {
+              return cb(formatError(err));
+            }
             return cb(err);
           } else if (res.error === true) {
             if(_.isObject(res.body)) {
@@ -518,9 +535,8 @@ module.exports = function (config, deps) {
         function (err, res) {
 
           if (err != null) {
-            err.sessionToken = user.getUserToken();
             if (err.status !== 200) {
-              return cb((err.response && err.response.body) || err);
+              return cb(formatError(err));
             }
             return cb(err);
           } else if (res.status !== 200) {
@@ -554,9 +570,8 @@ module.exports = function (config, deps) {
         function (err, res) {
 
           if (err != null) {
-            err.sessionToken = user.getUserToken();
             if (err.status !== 200) {
-              return cb((err.response && err.response.body) || err);
+              return cb(formatError(err));
             }
             return cb(err);
           } else if (res.status !== 200) {

--- a/index.js
+++ b/index.js
@@ -480,7 +480,7 @@ module.exports = function (config, deps) {
         .end(
         function (err, res) {
           if (err != null) {
-            return cb(err);
+            return cb(err, res);
           } else if (res.error === true) {
             if(_.isObject(res.body)) {
               return cb(res.body); // for our custom error arrays
@@ -517,7 +517,7 @@ module.exports = function (config, deps) {
         function (err, res) {
 
           if (err != null) {
-            return cb(err);
+            return cb(err, res);
           } else if (res.status !== 200) {
             return cb(res.body);
           }
@@ -549,7 +549,7 @@ module.exports = function (config, deps) {
         function (err, res) {
 
           if (err != null) {
-            return cb(err);
+            return cb(err, res);
           } else if (res.status !== 200) {
             return cb(res.body);
           }

--- a/index.js
+++ b/index.js
@@ -480,6 +480,7 @@ module.exports = function (config, deps) {
         .end(
         function (err, res) {
           if (err != null) {
+            res.sessionToken = user.getUserToken();
             return cb(err, res);
           } else if (res.error === true) {
             if(_.isObject(res.body)) {
@@ -517,6 +518,7 @@ module.exports = function (config, deps) {
         function (err, res) {
 
           if (err != null) {
+            res.sessionToken = user.getUserToken();
             return cb(err, res);
           } else if (res.status !== 200) {
             return cb(res.body);
@@ -549,6 +551,7 @@ module.exports = function (config, deps) {
         function (err, res) {
 
           if (err != null) {
+            res.sessionToken = user.getUserToken();
             return cb(err, res);
           } else if (res.status !== 200) {
             return cb(res.body);

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var _ = require('lodash');
-var uuid = require('node-uuid');
+var uuidv4 = require('uuid/v4');
 
 var id = require('./lib/id.js');
 
@@ -148,6 +148,7 @@ module.exports = function (config, deps) {
           superagent
             .get(common.makeAPIUrl('/metrics/thisuser/' + config.metricsSource + ' - ' + eventname))
             .set(common.SESSION_TOKEN_HEADER, token)
+            .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
             .query(properties)
             .end(doNothingCB);
         }
@@ -190,6 +191,7 @@ module.exports = function (config, deps) {
           superagent
             .get(common.makeAPIUrl('/metrics/thisuser/' + config.metricsSource + ' - ' + eventname))
             .set(common.SESSION_TOKEN_HEADER, token)
+            .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
             .query(properties)
             .end(doNothingCB);
         }
@@ -474,6 +476,7 @@ module.exports = function (config, deps) {
         .post(common.makeDataUrl('/v1/users/' + userId + '/datasets'))
         .send(info)
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
+        .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
         .end(
         function (err, res) {
           if (err != null) {
@@ -509,6 +512,7 @@ module.exports = function (config, deps) {
         .put(common.makeDataUrl('/v1/datasets/' + datasetId))
         .send({dataState: 'closed'})
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
+        .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
         .end(
         function (err, res) {
 
@@ -540,6 +544,7 @@ module.exports = function (config, deps) {
         .post(common.makeDataUrl('/v1/datasets/' + datasetId + '/data'))
         .send(data)
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
+        .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
         .end(
         function (err, res) {
 
@@ -572,6 +577,7 @@ module.exports = function (config, deps) {
         .post(common.makeUploadUrl('/data/'+userId))
         .send(data)
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
+        .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
         .end(
         function (err, res) {
 
@@ -659,6 +665,7 @@ module.exports = function (config, deps) {
             superagent
               .get(common.makeUploadUrl('/v1/synctasks/' + syncTaskId))
               .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
+              .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
               .end(
                 function (err, res) {
                   if (!_.isEmpty(err)) {
@@ -693,6 +700,7 @@ module.exports = function (config, deps) {
         .send(formData)
         .type('form')
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
+        .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
         .end(
         function (err, res) {
           if (!_.isEmpty(err)) {
@@ -737,6 +745,7 @@ module.exports = function (config, deps) {
        superagent
         .get(common.makeUploadUrl('/v1/device/data/' + dataId))
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
+        .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
         .end(
         function (err, res) {
           if (err) {
@@ -813,7 +822,7 @@ module.exports = function (config, deps) {
 
       common.doPostWithToken(
         '/message/reply/' + comment.parentmessage,
-        { message: _.assign(comment, {guid: uuid.v4()}) },
+        { message: _.assign(comment, {guid: uuidv4()}) },
         { 201: function(res){ return res.body.id; }},
         cb
       );
@@ -834,7 +843,7 @@ module.exports = function (config, deps) {
 
       common.doPostWithToken(
         '/message/send/' + message.groupid,
-        { message: _.assign(message, {guid: uuid.v4()}) },
+        { message: _.assign(message, {guid: uuidv4()}) },
         { 201: function(res){ return res.body.id; }},
         cb
       );

--- a/lib/common.js
+++ b/lib/common.js
@@ -18,6 +18,7 @@
 'use strict';
 
 var _ = require('lodash');
+var uuidv4 = require('uuid/v4');
 
 module.exports = function (cfg, deps) {
 
@@ -31,9 +32,11 @@ module.exports = function (cfg, deps) {
   var bliphost = config.bliphost;
 
   var usersToken;
+  var sessionTrace = config.sessionTrace || uuidv4();
 
   //constants
   var SESSION_TOKEN_HEADER = 'x-tidepool-session-token';
+  var TRACE_SESSION_HEADER = 'x-tidepool-trace-session';
   var STATUS_BAD_REQUEST = 400;
   var STATUS_UNAUTHORIZED = 401;
   var STATUS_UNAUTHORIZED_MSG = 'User is not logged in, you must log in to do this operation';
@@ -60,6 +63,14 @@ module.exports = function (cfg, deps) {
 
   function getToken() {
     return usersToken;
+  }
+
+  function setSessionTrace(newTrace) {
+    sessionTrace = newTrace;
+  }
+
+  function getSessionTrace() {
+    return sessionTrace;
   }
 
   //return errors in a consistent way
@@ -106,7 +117,7 @@ module.exports = function (cfg, deps) {
       return null;
     }
     // We previously exposed the user's session id here - which we identified as a security risk.
-    // We would have just removed the token query param altogether, but the URl that we direct user's to 
+    // We would have just removed the token query param altogether, but the URl that we direct user's to
     // is configured in a way where the token needs to be set for the Chrome Uploader to be launched
     // So for now we are setting the token to a constant.
     return makeUploadUrl('', { launchUploader: 'true' });
@@ -210,6 +221,7 @@ module.exports = function (cfg, deps) {
       superagent
         .get(self.makeAPIUrl(path))
         .set(self.SESSION_TOKEN_HEADER, token)
+        .set(self.TRACE_SESSION_HEADER, getSessionTrace())
         .end(
         function (err, res) {
           if (err != null) {
@@ -254,6 +266,7 @@ module.exports = function (cfg, deps) {
           .post(self.makeAPIUrl(path))
           .send(data)
           .set(self.SESSION_TOKEN_HEADER, token)
+          .set(self.TRACE_SESSION_HEADER, getSessionTrace())
           .end(
           function (err, res) {
             if (err != null) {
@@ -298,6 +311,7 @@ module.exports = function (cfg, deps) {
           .put(self.makeAPIUrl(path))
           .send(data)
           .set(self.SESSION_TOKEN_HEADER, token)
+          .set(self.TRACE_SESSION_HEADER, getSessionTrace())
           .end(
           function (err, res) {
             if (err != null) {
@@ -321,6 +335,7 @@ module.exports = function (cfg, deps) {
   return {
     //Constants
     SESSION_TOKEN_HEADER : SESSION_TOKEN_HEADER,
+    TRACE_SESSION_HEADER : TRACE_SESSION_HEADER,
     STATUS_BAD_REQUEST : STATUS_BAD_REQUEST,
     STATUS_UNAUTHORIZED : STATUS_UNAUTHORIZED,
     STATUS_UNAUTHORIZED_MSG : STATUS_UNAUTHORIZED_MSG,
@@ -329,6 +344,8 @@ module.exports = function (cfg, deps) {
     //Tokens
     syncToken : syncToken,
     getToken : getToken,
+    setSessionTrace : setSessionTrace,
+    getSessionTrace : getSessionTrace,
     //Endpoints
     makeAPIUrl : makeAPIUrl,
     makeUploadUrl : makeUploadUrl,

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "async": "0.9.0",
     "crypto": "0.0.3",
     "lodash": "3.3.1",
-    "node-uuid": "1.4.3",
-    "superagent": "0.21.0"
+    "superagent": "0.21.0",
+    "uuid": "3.1.0"
   },
   "devDependencies": {
     "grunt": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-platform-client",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "scripts": {


### PR DESCRIPTION
What it says on the tin, and also switches to the `uuid` node package instead of the deprecated `node-uuid` package.