### PR TITLE
URI encode query params for export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1040,6 +1040,7 @@ module.exports = function (config, deps) {
      * Get URL for data export for a given user
      *
      * @param {String} userId of the user to get data for
+     * @param {String} loggedInUserId the userId of the logged in user
      * @param {Object} options
      * @param {String} options.format 'json'|'excel'
      * @param {String} options.startDate
@@ -1047,9 +1048,9 @@ module.exports = function (config, deps) {
      * @param cb
      * @returns {cb} cb(err, response)
      */
-    getExportDataURL: function (userId, options, cb){
-      common.assertArgumentsSize(arguments, 3);
-      user.createRestrictedTokenForUser(userId, {}, function(err, response){
+    getExportDataURL: function (userId, loggedInUserId, options, cb){
+      common.assertArgumentsSize(arguments, 4);
+      user.createRestrictedTokenForUser(loggedInUserId, {}, function(err, response){
         if (err) {
           cb(err);
         }

--- a/lib/common.js
+++ b/lib/common.js
@@ -198,7 +198,7 @@ module.exports = function (cfg, deps) {
       result += '?';
       var fields = [];
       for (var k in query) {
-        fields.push(k + '=' + query[k]);
+        fields.push(k + '=' + encodeURIComponent(query[k]));
       }
       result += fields.join('&');
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-platform-client",
-  "version": "0.42.0-export-units.1",
+  "version": "0.41.0-export-units.2",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-platform-client",
-  "version": "0.40.0",
+  "version": "0.41.0-export-units.1",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "scripts": {


### PR DESCRIPTION
Specifically to handle bg units which include a `/` in their string value. [WEB-34] [WEB-31]
Pairs with https://github.com/tidepool-org/blip/pull/543

[WEB-34]: https://tidepool.atlassian.net/browse/WEB-34
[WEB-31]: https://tidepool.atlassian.net/browse/WEB-31