### PR TITLE
[WEB-829] Add retries to API calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: node_js
+
 node_js:
-  - 6.10.2
+  - "10.14.2"
   - node
+
 script:
-- npm test
+  - npm test
+
+matrix:
+  allow_failures:
+    - node_js: node

--- a/confirm.js
+++ b/confirm.js
@@ -51,6 +51,7 @@ module.exports = function (common, deps) {
       common.assertArgumentsSize(arguments, 2);
       superagent
        .put(common.makeAPIUrl('/confirm/accept/signup/'+signupId))
+       .retry()
        .end(function (err, res) {
         if (err != null) {
           // TODO: update version of lodash so we can use _.get
@@ -77,6 +78,7 @@ module.exports = function (common, deps) {
       superagent
        .put(common.makeAPIUrl('/confirm/accept/signup/'+signupId))
        .send({birthday: birthday, password: password})
+       .retry()
        .end(function (err, res) {
         if (err != null) {
           err.error = (err.response && err.response.body && err.response.body.error) || '';
@@ -100,6 +102,7 @@ module.exports = function (common, deps) {
       common.assertArgumentsSize(arguments, 2);
       superagent
        .post(common.makeAPIUrl('/confirm/resend/signup/' + email))
+       .retry()
        .end(function (err, res) {
         if (err != null) {
           err.message = (err.response && err.response.error) || '';
@@ -156,6 +159,7 @@ module.exports = function (common, deps) {
       superagent
         .get(common.makeAPIUrl('/confirm/invitations/'+inviteeId))
         .set(common.SESSION_TOKEN_HEADER, common.getToken())
+        .retry()
         .end(
         function (err, res) {
           if (err != null) {
@@ -259,6 +263,7 @@ module.exports = function (common, deps) {
 
       superagent
        .post(common.makeAPIUrl('/confirm/send/forgot/' + email))
+       .retry()
        .end(function (err, res) {
         if (err != null) {
           err.message = (err.response && err.response.error) || '';
@@ -287,6 +292,7 @@ module.exports = function (common, deps) {
       superagent
        .put(common.makeAPIUrl('/confirm/accept/forgot'))
        .send(payload)
+       .retry()
        .end(function (err, res) {
         if (err != null) {
           err.message = (err.response && err.response.error) || '';

--- a/index.js
+++ b/index.js
@@ -165,6 +165,7 @@ module.exports = function (config, deps) {
             .set(common.SESSION_TOKEN_HEADER, token)
             .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
             .query(properties)
+            .retry()
             .end(doNothingCB);
         }
       );
@@ -208,6 +209,7 @@ module.exports = function (config, deps) {
             .set(common.SESSION_TOKEN_HEADER, token)
             .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
             .query(properties)
+            .retry()
             .end(doNothingCB);
         }
       );
@@ -475,6 +477,7 @@ module.exports = function (config, deps) {
       common.assertArgumentsSize(arguments, 1);
       superagent
         .get(common.makeUploadUrl('/info'))
+        .retry()
         .end(
         function (err, res) {
           if (err != null) {
@@ -492,6 +495,7 @@ module.exports = function (config, deps) {
     getTime: function (cb) {
       superagent
         .get(common.makeDataUrl('/v1/time'))
+        .retry()
         .end(
         function (err, res) {
           if (err != null) {
@@ -536,6 +540,7 @@ module.exports = function (config, deps) {
         .send(info)
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
+        .retry()
         .end(
         function (err, res) {
           if (err != null) {
@@ -575,6 +580,7 @@ module.exports = function (config, deps) {
         .send({dataState: 'closed'})
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
+        .retry()
         .end(
         function (err, res) {
 
@@ -610,6 +616,7 @@ module.exports = function (config, deps) {
         .send(data)
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
+        .retry()
         .end(
         function (err, res) {
 
@@ -646,6 +653,7 @@ module.exports = function (config, deps) {
         .send(data)
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
+        .retry()
         .end(
         function (err, res) {
 
@@ -685,6 +693,7 @@ module.exports = function (config, deps) {
       .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
       .set(common.DIGEST_HEADER, digest)
       .type(contentType)
+      .retry()
       .end(
       function (err, res) {
        if (err != null) {
@@ -776,6 +785,7 @@ module.exports = function (config, deps) {
               .get(common.makeUploadUrl('/v1/synctasks/' + syncTaskId))
               .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
               .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
+              .retry()
               .end(
                 function (err, res) {
                   if (!_.isEmpty(err)) {
@@ -812,6 +822,7 @@ module.exports = function (config, deps) {
         .type('form')
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
+        .retry()
         .end(
         function (err, res) {
           if (!_.isEmpty(err)) {
@@ -858,6 +869,7 @@ module.exports = function (config, deps) {
         .get(common.makeUploadUrl('/v1/device/data/' + dataId))
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
+        .retry()
         .end(
         function (err, res) {
           if (err) {
@@ -892,6 +904,7 @@ module.exports = function (config, deps) {
         .get(common.makeDataUrl('/v1/users/' + userId + '/data_sets?deviceId=' + deviceId + '&size=' + size))
         .set(common.SESSION_TOKEN_HEADER, user.getUserToken())
         .set(common.TRACE_SESSION_HEADER, common.getSessionTrace())
+        .retry()
         .end(
           function (err, res) {
             if (err) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -258,6 +258,7 @@ module.exports = function (cfg, deps) {
         .get(self.makeAPIUrl(path))
         .set(self.SESSION_TOKEN_HEADER, token)
         .set(self.TRACE_SESSION_HEADER, getSessionTrace())
+        .retry()
         .end(
         function (err, res) {
           if (err != null) {
@@ -312,6 +313,7 @@ module.exports = function (cfg, deps) {
           .send(data)
           .set(self.SESSION_TOKEN_HEADER, token)
           .set(self.TRACE_SESSION_HEADER, getSessionTrace())
+          .retry()
           .end(
           function (err, res) {
             if (err != null) {
@@ -366,6 +368,7 @@ module.exports = function (cfg, deps) {
           .send(data)
           .set(self.SESSION_TOKEN_HEADER, token)
           .set(self.TRACE_SESSION_HEADER, getSessionTrace())
+          .retry()
           .end(
           function (err, res) {
             if (err != null) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async": "0.9.0",
     "lodash": "3.3.1",
-    "superagent": "1.2.0",
+    "superagent": "5.2.2",
     "uuid": "3.1.0"
   },
   "devDependencies": {

--- a/user.js
+++ b/user.js
@@ -86,6 +86,7 @@ module.exports = function (common, config, deps) {
   function refreshUserToken(token, cb) {
     superagent.get(common.makeAPIUrl('/auth/login'))
       .set(common.SESSION_TOKEN_HEADER, token)
+      .retry()
       .end(
       function (err, res) {
         if (err) {
@@ -187,6 +188,7 @@ module.exports = function (common, config, deps) {
     superagent
       .post(common.makeAPIUrl('/auth/oauthlogin'))
       .set('Authorization', 'bearer '+oauthToken)
+      .retry()
       .end(
       function (err, res) {
 
@@ -231,6 +233,7 @@ module.exports = function (common, config, deps) {
     superagent
       .post(common.makeAPIUrl('/auth/login', user.longtermkey))
       .auth(user.username, user.password)
+      .retry()
       .end(
       function (err, res) {
         if (err != null) {
@@ -300,6 +303,7 @@ module.exports = function (common, config, deps) {
     superagent
       .post(common.makeAPIUrl('/auth/user'))
       .send(newUser)
+      .retry()
       .end(
       function (err, res) {
         if (err != null) {
@@ -338,6 +342,7 @@ module.exports = function (common, config, deps) {
        .post(common.makeAPIUrl('/auth/user/' + getUserId() + '/user'))
        .set(common.SESSION_TOKEN_HEADER, getUserToken())
        .send(body)
+       .retry()
        .end(
        function (err, res) {
         if (err != null) {
@@ -358,6 +363,7 @@ module.exports = function (common, config, deps) {
         .put(common.makeAPIUrl('/metadata/'+ custodialUser.id + '/profile'))
         .send(profile)
         .set(common.SESSION_TOKEN_HEADER, getUserToken())
+        .retry()
         .end(
           function (err, res) {
             if (err != null) {
@@ -380,6 +386,7 @@ module.exports = function (common, config, deps) {
         .post(common.makeAPIUrl('/confirm/send/signup/'+custodialUser.id))
         .set(common.SESSION_TOKEN_HEADER, getUserToken())
         .send({})
+        .retry()
         .end(
           function (err, res) {
             if (err != null) {
@@ -517,6 +524,7 @@ module.exports = function (common, config, deps) {
     superagent
       .del(common.makeAPIUrl('/v1/oauth/' + provider + '/authorize'))
       .set(common.SESSION_TOKEN_HEADER, getUserToken())
+      .retry()
       .end(
       function(err, res) {
         if (err != null) {


### PR DESCRIPTION
For [WEB-829] and one of the dependencies in [SECURITY-19].

This will update `superagent` to latest and add `.retry()` (default 3x) to all our API calls which will retry on likely transient HTTP errors.

[WEB-829]: https://tidepool.atlassian.net/browse/WEB-829
[SECURITY-19]: https://tidepool.atlassian.net/browse/SECURITY-19