### PR TITLE
[WEB-1372] keycloak

### DIFF
--- a/index.js
+++ b/index.js
@@ -1094,6 +1094,7 @@ module.exports = function (config, deps) {
     createRestrictedTokenForUser: user.createRestrictedTokenForUser,
     createOAuthProviderAuthorization: user.createOAuthProviderAuthorization,
     deleteOAuthProviderAuthorization: user.deleteOAuthProviderAuthorization,
+    saveSession: user.saveSession,
     /**
      * Signup
      */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-platform-client",
-  "version": "0.48.0",
+  "version": "0.49.0-web-1372-keycloak.1",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-platform-client",
-  "version": "0.49.0-web-1372-keycloak.1",
+  "version": "0.49.0-web-1372-keycloak.2",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "scripts": {

--- a/user.js
+++ b/user.js
@@ -102,9 +102,18 @@ module.exports = function (common, config, deps) {
   }
   /**
    * Save user session (in-memory and stored in browser)
+   * @param newUserId user Id
+   * @param newToken session token
+   * @param options (optional) object with options `remember`, `noRefresh`
+   * @param cb
+   * @returns {cb} cb(err, response)
    */
-  function saveSession(newUserId, newToken, options) {
+  function saveSession(newUserId, newToken, options, cb) {
     options = options || {};
+    if (typeof options === 'function') {
+      cb = options;
+      options = {};
+    }
     myToken = newToken;
     common.syncToken(myToken);
     myUserId = newUserId;
@@ -147,6 +156,8 @@ module.exports = function (common, config, deps) {
     if(!options.noRefresh){
       setTimeout(refreshSession, config.tokenRefreshInterval);
     }
+
+    return cb(null, {userId: myUserId, token: myToken});
   }
   /**
    * Destroy user session (in-memory and stored in browser)

--- a/user.js
+++ b/user.js
@@ -114,6 +114,7 @@ module.exports = function (common, config, deps) {
       cb = options;
       options = {};
     }
+    cb = cb ?? _.noop;
     myToken = newToken;
     common.syncToken(myToken);
     myUserId = newUserId;

--- a/user.js
+++ b/user.js
@@ -144,7 +144,9 @@ module.exports = function (common, config, deps) {
       });
     };
 
-    setTimeout(refreshSession, config.tokenRefreshInterval);
+    if(!options.noRefresh){
+      setTimeout(refreshSession, config.tokenRefreshInterval);
+    }
   }
   /**
    * Destroy user session (in-memory and stored in browser)
@@ -556,6 +558,7 @@ module.exports = function (common, config, deps) {
     updateCustodialUser: updateCustodialUser,
     createRestrictedTokenForUser: createRestrictedTokenForUser,
     createOAuthProviderAuthorization: createOAuthProviderAuthorization,
-    deleteOAuthProviderAuthorization: deleteOAuthProviderAuthorization
+    deleteOAuthProviderAuthorization: deleteOAuthProviderAuthorization,
+    saveSession: saveSession,
   };
 };


### PR DESCRIPTION
For [WEB-1372] - exposes the previously private `saveSession` so consuming apps can set authentication directly (needed for keycloak to pass down the session tokens) and optionally allows for turning off the internal session refresh (if, for instance, it's being handled externally by keycloak)

See also: https://github.com/tidepool-org/blip/pull/1031

[WEB-1372]: https://tidepool.atlassian.net/browse/WEB-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ