### PR TITLE
[WEB-2599] network timeouts (hotfix)

### DIFF
--- a/clinics.js
+++ b/clinics.js
@@ -462,7 +462,7 @@ module.exports = function (common) {
       common.assertArgumentsSize(2);
       common.doGetWithToken(
         `/v1/clinics/${clinicId}/settings/mrn`,
-        { 200: function(res){ return res.body; } },
+        { 200: function(res){ return res.body; }, 404: {} },
         cb
       );
     },
@@ -478,7 +478,7 @@ module.exports = function (common) {
       common.assertArgumentsSize(2);
       common.doGetWithToken(
         `/v1/clinics/${clinicId}/settings/ehr`,
-        { 200: function(res){ return res.body; } },
+        { 200: function(res){ return res.body; }, 404: {} },
         cb
       );
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-platform-client",
-  "version": "0.54.0",
+  "version": "0.54.1-web-2599-timeouts",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-platform-client",
-  "version": "0.54.1-web-2599-timeouts",
+  "version": "0.54.1",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "scripts": {


### PR DESCRIPTION
to handle [WEB-2599] timeouts from sending extraneous traffic to metrics endpoints

blip pr: https://github.com/tidepool-org/blip/pull/1301

[WEB-2599]: https://tidepool.atlassian.net/browse/WEB-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ