### PR TITLE
[WEB-2958] Send active patient filters to RPM report generation endpoint

### DIFF
--- a/clinics.js
+++ b/clinics.js
@@ -757,7 +757,10 @@ module.exports = function (common) {
         cb = options;
         options = {};
       }
-      if(!_.isEmpty(options)){
+      if (!_.isEmpty(options)) {
+        if (_.isPlainObject(options.patientFilters)) {
+          options.patientFilters = JSON.stringify(options.patientFilters);
+        }
         url += '?' + common.serialize(options);
       }
       common.doGetWithToken(

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=18"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "0.58.0-rc.1",
+  "version": "0.58.0-rc.2",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "repository": "https://github.com/tidepool-org/platform-client.git",


### PR DESCRIPTION
[WEB-2958] 

[WEB-2958]: https://tidepool.atlassian.net/browse/WEB-2958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ