### PR TITLE
WEB-3071 smart on fhir launch

### DIFF
--- a/clinics.js
+++ b/clinics.js
@@ -854,5 +854,35 @@ module.exports = function (common) {
         cb
       );
     },
+
+    /**
+     * Get list of patients
+     *
+     * @param {Object} [options] - search options
+     * @param {String} [options.search] - search query string
+     * @param {String} [options.mrn] - Medical Record Number
+     * @param {String} [options.birthDate] - Patient birth date
+     * @param {String} [options.workspaceId] - Workspace identifier
+     * @param {String} [options.workspaceIdType] - Type of workspace ID (clinicId or ehrSourceId)
+     * @param {Number} [options.offset] - search page offset
+     * @param {Number} [options.limit] - results per page
+     * @param {Function} cb
+     * @returns {cb} cb(err, response)
+    */
+    getPatients: function(options = {}, cb){
+      var url = '/v1/patients';
+      if(_.isFunction(options) && _.isUndefined(cb)){
+        cb = options;
+        options = {};
+      }
+      if(!_.isEmpty(options)){
+        url += '?' + common.serialize(options);
+      }
+      common.doGetWithToken(
+        url,
+        { 200: function(res){ return res.body; }, 404: [] },
+        cb
+      )
+    },
   };
 };

--- a/index.js
+++ b/index.js
@@ -1175,5 +1175,6 @@ module.exports = function (config, deps) {
     getClinicPatientCountSettings: clinics.getClinicPatientCountSettings,
     setClinicPatientLastReviewed: clinics.setClinicPatientLastReviewed,
     revertClinicPatientLastReviewed: clinics.revertClinicPatientLastReviewed,
+    getPatients: clinics.getPatients,
   };
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=18"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "0.64.0-web-3071-smart-on-fhir.2",
+  "version": "0.64.0-web-3071-smart-on-fhir.3",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "repository": "https://github.com/tidepool-org/platform-client.git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=18"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "0.62.0-web-3400-strip-clinic-patient-update-fields.1",
+  "version": "0.62.0-web-3071-smart-on-fhir.1",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "repository": "https://github.com/tidepool-org/platform-client.git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=18"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "0.64.0-web-3071-smart-on-fhir.3",
+  "version": "0.64.0-web-3071-smart-on-fhir.4",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "repository": "https://github.com/tidepool-org/platform-client.git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=18"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "0.63.0",
+  "version": "0.64.0-web-3071-smart-on-fhir.2",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "repository": "https://github.com/tidepool-org/platform-client.git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=18"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "0.64.0-web-3071-smart-on-fhir.4",
+  "version": "0.65.0-web-3071-smart-on-fhir.5",
   "description": "Client-side library to interact with the Tidepool platform",
   "main": "tidepool.js",
   "repository": "https://github.com/tidepool-org/platform-client.git",


### PR DESCRIPTION
to support [WEB-3071] and https://github.com/tidepool-org/blip/pull/1531
This pull request adds a new method to fetch a list of patients with various search options, exposes this method through the main module, and updates the package version to reflect these changes.

**New patient search functionality:**

* Added a `getPatients` method to the `clinics.js` module, allowing retrieval of a patient list with support for search query, MRN, birth date, workspace ID, pagination, and other options.
* Exposed the `getPatients` method in the main module's public API by adding it to the exports in `index.js`.

[WEB-3071]: https://tidepool.atlassian.net/browse/WEB-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ